### PR TITLE
strip slash from beginning of the paths if exists

### DIFF
--- a/libs/resources.js
+++ b/libs/resources.js
@@ -26,6 +26,9 @@ var expandResources = function (resourcePath, opts, contentDir) {
         throw new gutil.PluginError('gulp-resources', 'Unknown type of "cwd".');
     }
 
+    // Strip slash from beginning of the path if exists
+    resourcePath = resourcePath.indexOf("/") === 0 ? resourcePath.slice(1) : resourcePath;
+    
     _.forEach(dirs, function (dir) {
         resources = glob.sync(resourcePath, { cwd : dir });
         if (resources.length) {


### PR DESCRIPTION
Slash at the beginning of the resource files cause a "file not found" error when evaluating `glob.sync(resourcePath, { cwd : dir });`. That's because the path will be treated as absolute path which is wrong.
